### PR TITLE
Add bottles for pre-built binaries

### DIFF
--- a/Formula/autokbisw.rb
+++ b/Formula/autokbisw.rb
@@ -5,6 +5,13 @@ class Autokbisw < Formula
   version "1.2.0"
   sha256 "1c3bfad19b9025ad15f01ea0554351f47225807efd85cb4b4f0b6e1785af3f3e"
     
+  bottle do
+    root_url 'https://github.com/jeantil/autokbisw/releases/download/1.2.0'
+    sha256 'a1f03198e3b1456b00ce5f0ddd7185ff0a03e8a4c3d3a4745f80306fc2074f6a' => :mavericks
+    sha256 'xxx' => :high_sierra
+    sha256 'yyy' => :sierra
+  end
+
   depends_on :xcode
     
   def install


### PR DESCRIPTION
I've added a "bottles" stanza which should allow brew to simply download pre-built binaries (as per a request to me on an internal forum here.)

I think it might need a couple of things from you though:
* The binary needs to be renamed `autokbisw-1.2.0.mavericks.bottle.tar.gz` (the current one is missing both the version number and the OS release from the name)
* The release process should add `high_sierra` and `sierra` binaries. 

I'm not 100% sure if we need three versions, or just one version named for the earliest version of macOS it supports, [the docs are unclear](https://docs.brew.sh/Bottles), and [this](https://github.com/Homebrew/legacy-homebrew/issues/31812) is the only documentation I could find detailing how to do bottles for 3rd party taps off a GitHub release, and it's quite old.

(As an aside I generated the hash with `openssl dgst -sha256 ~/Downloads/autokbisw.tar.gz`, if you need to fill in the others.)