### PR TITLE
Use standard Brew prefix for log path

### DIFF
--- a/Formula/autokbisw.rb
+++ b/Formula/autokbisw.rb
@@ -42,9 +42,9 @@ class Autokbisw < Formula
         <true/>
         <!--
         <key>StandardOutPath</key>
-        <string>/usr/local/var/log/autokbisw.log</string>
+        <string>${var}/log/autokbisw.log</string>
         <key>StandardErrorPath</key>
-        <string>/usr/local/var/log/autokbisw.log</string>
+        <string>${var}/log/autokbisw.log</string>
         -->
         <key>StandardErrorPath</key>
         <string>/dev/null</string>


### PR DESCRIPTION
Something that came up in my quest to work out how to create a bottle properly: 

```
==> Detecting if autokbisw--1.2.0.mojave.bottle.tar.gz is relocatable...
Warning: String '/usr/local/var' still exists in these files:
/usr/local/Cellar/autokbisw/1.2.0/.brew/autokbisw.rb
 --> match '<string>/usr/local/var/log/autokbisw.log</string>' at offset 0x487
 --> match '<string>/usr/local/var/log/autokbisw.log</string>' at offset 0x4e6
```